### PR TITLE
feat: change error casting in go113

### DIFF
--- a/rabbitmq/util.go
+++ b/rabbitmq/util.go
@@ -10,7 +10,7 @@ import (
 )
 
 func checkDeleted(d *schema.ResourceData, err error) error {
-	var errorResponse *rabbithole.ErrorResponse
+	var errorResponse rabbithole.ErrorResponse
 	if errors.As(err, &errorResponse) {
 		if errorResponse.StatusCode == 404 {
 			d.SetId("")

--- a/rabbitmq/util.go
+++ b/rabbitmq/util.go
@@ -1,6 +1,7 @@
 package rabbitmq
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,14 +10,13 @@ import (
 )
 
 func checkDeleted(d *schema.ResourceData, err error) error {
-	switch e := err.(type) {
-	case rabbithole.ErrorResponse:
-		if e.StatusCode == 404 {
+	var errorResponse *rabbithole.ErrorResponse
+	if errors.As(err, &errorResponse) {
+		if errorResponse.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
 	}
-
 	return err
 }
 


### PR DESCRIPTION
# objective
seems go 1.13 introduces a better way for error casting should we change the statement like my commit ?

# reason
seems the minimum go version is already >= 1.13

https://github.com/cyrilgdn/terraform-provider-rabbitmq/blob/master/.travis.yml#L7 

# reference
https://github.com/golang/go/wiki/ErrorValueFAQ