### PR TITLE
arg ref for clientcert_file and clientkey_file

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -58,3 +58,7 @@ The following arguments are supported:
   from the `RABBITMQ_INSECURE` Environment Variable.
 * `cacert_file` - (Optional) The path to a custom CA / intermediate certificate.
   This can also be sourced from the `RABBITMQ_CACERT` Environment Variable.
+* `clientcert_file` - (Optional) The path to the X.509 client certificate
+  This can also be source from the `RABBITMQ_CLIENTCERT` Environment Variable
+* `clientkey_file` - (Optional) The path to the private key 
+  This can also be source from the `RABBITMQ_CLIENTKEY` Environment Variable


### PR DESCRIPTION
Added argument references for `clientcert_file` and `clientkey_file`. These 2 arguments have been [committed](https://github.com/hashicorp/terraform-provider-rabbitmq/pull/29/files/3d1a38a31ca018d2ef5344276bbff1b69c9d6014) by Samuel Dumont in version 1.4.0 but never documented properly.