### PR TITLE
Allow configuration of a RabbitMQ-specific proxy

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -58,7 +58,11 @@ The following arguments are supported:
   from the `RABBITMQ_INSECURE` Environment Variable.
 * `cacert_file` - (Optional) The path to a custom CA / intermediate certificate.
   This can also be sourced from the `RABBITMQ_CACERT` Environment Variable.
-* `clientcert_file` - (Optional) The path to the X.509 client certificate
-  This can also be source from the `RABBITMQ_CLIENTCERT` Environment Variable
-* `clientkey_file` - (Optional) The path to the private key 
-  This can also be source from the `RABBITMQ_CLIENTKEY` Environment Variable
+* `clientcert_file` - (Optional) The path to the X.509 client certificate.
+  This can also be sourced from the `RABBITMQ_CLIENTCERT` Environment Variable
+* `clientkey_file` - (Optional) The path to the private key.
+  This can also be sourced from the `RABBITMQ_CLIENTKEY` Environment Variable
+* `proxy` - (Optional) The URL of a proxy through which to send HTTP requests to
+  the RabbitMQ server. This can also be sourced from the `RABBITMQ_PROXY`
+  Environment Variable. If not set, the default `HTTP_PROXY`/`HTTPS_PROXY` will
+  be used instead.


### PR DESCRIPTION
We're using a managed Amazon MQ broker, and it's only accessible from within the VPC. We can access it with a SOCKS5 proxy, tunnelling in via an EC2 instance that's running in the VPC. However, setting a global proxy (e.g. `HTTPS_PROXY=socks5://localhost:8080`) means that _all_ traffic from Terraform is sent through the tunnel, but we want to limit it to just traffic to the RabbitMQ management API.

This PR adds a `proxy` option to the provider to support this use case.