### PR TITLE
Added vhost, user and exchange datasources

### DIFF
--- a/rabbitmq/data_source_exchange.go
+++ b/rabbitmq/data_source_exchange.go
@@ -1,0 +1,95 @@
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourcesExchange() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcesReadExchange,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"vhost": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "/",
+			},
+			"settings": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"durable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
+						"auto_delete": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
+						"arguments": {
+							Type:     schema.TypeMap,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourcesReadExchange(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	rmqc := meta.(*rabbithole.Client)
+
+	name := d.Get("name").(string)
+	vhost := d.Get("vhost").(string)
+	id := fmt.Sprintf("%s@%s", name, vhost)
+
+	exchangeSettings, err := rmqc.GetExchange(vhost, name)
+	if err != nil {
+		return diag.FromErr(checkDeleted(d, err))
+	}
+
+	log.Printf("[DEBUG] RabbitMQ: Exchange retrieved %s: %#v", id, exchangeSettings)
+
+	d.Set("name", exchangeSettings.Name)
+	d.Set("vhost", exchangeSettings.Vhost)
+
+	exchange := make([]map[string]interface{}, 1)
+	e := make(map[string]interface{})
+	e["type"] = exchangeSettings.Type
+	e["durable"] = exchangeSettings.Durable
+	e["auto_delete"] = exchangeSettings.AutoDelete
+	e["arguments"] = exchangeSettings.Arguments
+	exchange[0] = e
+	d.Set("settings", exchange)
+
+	d.SetId(id)
+
+	return diags
+}

--- a/rabbitmq/data_source_user.go
+++ b/rabbitmq/data_source_user.go
@@ -1,0 +1,65 @@
+package rabbitmq
+
+import (
+	"context"
+	"log"
+
+	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourcesUser() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcesReadUser,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcesReadUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	rmqc := meta.(*rabbithole.Client)
+
+	name := d.Get("name").(string)
+
+	user, err := rmqc.GetUser(name)
+	if err != nil {
+		return diag.FromErr(checkDeleted(d, err))
+	}
+
+	log.Printf("[DEBUG] RabbitMQ: User retrieved: %#v", user)
+
+	d.Set("name", user.Name)
+
+	if len(user.Tags) > 0 {
+		var tagList []string
+		for _, v := range user.Tags {
+			if v != "" {
+				tagList = append(tagList, v)
+			}
+		}
+		if len(tagList) > 0 {
+			d.Set("tags", tagList)
+		}
+	}
+
+	d.SetId(name)
+
+	return diags
+}

--- a/rabbitmq/data_source_vhost.go
+++ b/rabbitmq/data_source_vhost.go
@@ -1,0 +1,48 @@
+package rabbitmq
+
+import (
+	"context"
+	"log"
+
+	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourcesVhost() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcesReadVhost,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourcesReadVhost(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	rmqc := meta.(*rabbithole.Client)
+
+	name := d.Get("name").(string)
+
+	vhost, err := rmqc.GetVhost(name)
+	if err != nil {
+		return diag.FromErr(checkDeleted(d, err))
+	}
+
+	log.Printf("[DEBUG] RabbitMQ: Vhost retrieved: %#v", vhost)
+
+	d.Set("name", vhost.Name)
+
+	d.SetId(name)
+
+	return diags
+}

--- a/rabbitmq/provider.go
+++ b/rabbitmq/provider.go
@@ -102,6 +102,19 @@ func Provider() *schema.Provider {
 			"rabbitmq_vhost":               resourceVhost(),
 			"rabbitmq_shovel":              resourceShovel(),
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			// "rabbitmq_binding":             dataSourcesBinding(),
+			"rabbitmq_exchange": dataSourcesExchange(),
+			// "rabbitmq_permissions":         dataSourcesPermissions(),
+			// "rabbitmq_topic_permissions":   dataSourcesTopicPermissions(),
+			// "rabbitmq_federation_upstream": dataSourcesFederationUpstream(),
+			// "rabbitmq_operator_policy":     dataSourcesOperatorPolicy(),
+			// "rabbitmq_policy":              dataSourcesPolicy(),
+			// "rabbitmq_queue":               dataSourcesQueue(),
+			"rabbitmq_user":  dataSourcesUser(),
+			"rabbitmq_vhost": dataSourcesVhost(),
+			// "rabbitmq_shovel":              dataSourcesShovel(),
+		},
 
 		ConfigureFunc: providerConfigure,
 	}


### PR DESCRIPTION
Fixes #35

This PR introduces data sources for `rabbitmq_user`, `rabbitmq_vhost` and `rabbitmq_exchange` that can be used as such:
```hcl
data "rabbitmq_user" "test" {
  name = "mctest"
}

data "rabbitmq_vhost" "vhost" {
  name = "my_vhost"
}

data "rabbitmq_exchange" "test" {
  name  = "test"
  vhost = data.rabbitmq_vhost.vhost.name
}
```
Corresponding with these resources:
```hcl
resource "rabbitmq_user" "test" {
  name     = "mctest"
  password = "foobar"
  tags     = ["administrator", "management"]
}

resource "rabbitmq_vhost" "vhost" {
  name = "my_vhost"
}

resource "rabbitmq_exchange" "test" {
  name  = "test"
  vhost = rabbitmq_vhost.vhost.name

  settings {
    type        = "fanout"
    durable     = false
    auto_delete = true
  }
}
```