### PR TITLE
Fixes cyrilgdn/terraform-provider-rabbitmq#9

### DIFF
--- a/rabbitmq/resource_shovel.go
+++ b/rabbitmq/resource_shovel.go
@@ -109,7 +109,7 @@ func resourceShovel() *schema.Resource {
 							Default:  "amqp091",
 						},
 						"destination_publish_properties": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeMap,
 							Optional: true,
 							ForceNew: true,
 							Default:  nil,


### PR DESCRIPTION
The destination_publish_properties should be a map, not a string.