### PR TITLE
Modified destination_publish_properties to map

### DIFF
--- a/rabbitmq/resource_shovel.go
+++ b/rabbitmq/resource_shovel.go
@@ -109,7 +109,7 @@ func resourceShovel() *schema.Resource {
 							Default:  "amqp091",
 						},
 						"destination_publish_properties": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeMap,
 							Optional: true,
 							ForceNew: true,
 							Default:  nil,
@@ -379,7 +379,7 @@ func setShovelDefinition(shovelMap map[string]interface{}) interface{} {
 		shovelDefinition.DestinationProtocol = v
 	}
 
-	if v, ok := shovelMap["destination_publish_properties"].(string); ok {
+	if v, ok := shovelMap["destination_publish_properties"].(map[string]interface{}); ok {
 		shovelDefinition.DestinationPublishProperties = v
 	}
 


### PR DESCRIPTION
The RabbitMQ API is expecting destination_publish_properties to be a map but was getting a string.
The source of the issue was in rabbit-hole, and this modification is coming after a modification I did  on rabbit-hole that was merged here: https://github.com/michaelklishin/rabbit-hole/commit/4390616f323338995d8e28c0aa116a2b8f7752c0

This fix will only be compatible with rabbit-hole after this commit.  