### PR TITLE
Add already exists exceptions and enhance errors

### DIFF
--- a/rabbitmq/resource_exchange.go
+++ b/rabbitmq/resource_exchange.go
@@ -72,6 +72,13 @@ func CreateExchange(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("name").(string)
 	vhost := d.Get("vhost").(string)
+
+	// Check if already exists
+	_, not_found := rmqc.GetExchange(vhost, name)
+	if not_found == nil {
+		return fmt.Errorf("Error creating RabbitMQ exchange '%s': exchange already exists", name)
+	}
+
 	settingsList := d.Get("settings").([]interface{})
 
 	settingsMap, ok := settingsList[0].(map[string]interface{})

--- a/rabbitmq/resource_exchange.go
+++ b/rabbitmq/resource_exchange.go
@@ -148,7 +148,7 @@ func DeleteExchange(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("Error deleting RabbitMQ exchange: %s", resp.Status)
+		return fmt.Errorf("Error deleting RabbitMQ exchange '%s': %s", name, resp.Status)
 	}
 
 	return nil
@@ -182,7 +182,7 @@ func declareExchange(rmqc *rabbithole.Client, vhost string, name string, setting
 	}
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("Error declaring RabbitMQ exchange: %s", resp.Status)
+		return fmt.Errorf("Error declaring RabbitMQ exchange '%s': %s", name, resp.Status)
 	}
 
 	return nil

--- a/rabbitmq/resource_policy.go
+++ b/rabbitmq/resource_policy.go
@@ -71,6 +71,13 @@ func CreatePolicy(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("name").(string)
 	vhost := d.Get("vhost").(string)
+
+	// Check if already exists
+	_, not_found := rmqc.GetPolicy(vhost, name)
+	if not_found == nil {
+		return fmt.Errorf("Error creating RabbitMQ policy '%s': policy already exists", name)
+	}
+
 	policyList := d.Get("policy").([]interface{})
 
 	policyMap, ok := policyList[0].(map[string]interface{})

--- a/rabbitmq/resource_policy.go
+++ b/rabbitmq/resource_policy.go
@@ -190,7 +190,7 @@ func DeletePolicy(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("Error deleting RabbitMQ policy: %s", resp.Status)
+		return fmt.Errorf("Error deleting RabbitMQ policy '%s': %s", name, resp.Status)
 	}
 
 	return nil
@@ -244,7 +244,7 @@ func putPolicy(rmqc *rabbithole.Client, vhost string, name string, policyMap map
 	}
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("Error declaring RabbitMQ policy: %s", resp.Status)
+		return fmt.Errorf("Error declaring RabbitMQ policy '%s': %s", name, resp.Status)
 	}
 
 	return nil

--- a/rabbitmq/resource_queue.go
+++ b/rabbitmq/resource_queue.go
@@ -82,6 +82,13 @@ func CreateQueue(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("name").(string)
 	vhost := d.Get("vhost").(string)
+
+	// Check if already exists
+	_, not_found := rmqc.GetQueue(vhost, name)
+	if not_found == nil {
+		return fmt.Errorf("Error creating RabbitMQ queue '%s': queue already exists", name)
+	}
+
 	settingsList := d.Get("settings").([]interface{})
 
 	settingsMap, ok := settingsList[0].(map[string]interface{})

--- a/rabbitmq/resource_queue.go
+++ b/rabbitmq/resource_queue.go
@@ -187,7 +187,7 @@ func DeleteQueue(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("Error deleting RabbitMQ queue: %s", resp.Status)
+		return fmt.Errorf("Error deleting RabbitMQ queue '%s': %s", name, resp.Status)
 	}
 
 	return nil
@@ -217,7 +217,7 @@ func declareQueue(rmqc *rabbithole.Client, vhost string, name string, settingsMa
 	}
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("Error declaring RabbitMQ queue: %s", resp.Status)
+		return fmt.Errorf("Error declaring RabbitMQ queue '%s': %s", name, resp.Status)
 	}
 
 	return nil

--- a/rabbitmq/resource_user.go
+++ b/rabbitmq/resource_user.go
@@ -53,6 +53,12 @@ func CreateUser(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] RabbitMQ: Attempting to create user %s", name)
 
+	// Check if already exists
+	_, not_found := rmqc.GetUser(name)
+	if not_found == nil {
+		return fmt.Errorf("Error creating RabbitMQ user '%s': user already exists", name)
+	}
+
 	resp, err := rmqc.PutUser(name, userSettings)
 	log.Printf("[DEBUG] RabbitMQ: user creation response: %#v", resp)
 	if err != nil {

--- a/rabbitmq/resource_user.go
+++ b/rabbitmq/resource_user.go
@@ -146,7 +146,7 @@ func DeleteUser(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("Error deleting RabbitMQ user: %s", resp.Status)
+		return fmt.Errorf("Error deleting RabbitMQ user '%s': %s", name, resp.Status)
 	}
 
 	return nil

--- a/rabbitmq/resource_vhost.go
+++ b/rabbitmq/resource_vhost.go
@@ -35,6 +35,12 @@ func CreateVhost(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] RabbitMQ: Attempting to create vhost %s", vhost)
 
+	// Check if already exists
+	_, not_found := rmqc.GetVhost(vhost)
+	if not_found == nil {
+		return fmt.Errorf("Error creating RabbitMQ vhost '%s': vhost already exists", vhost)
+	}
+
 	resp, err := rmqc.PutVhost(vhost, rabbithole.VhostSettings{})
 	log.Printf("[DEBUG] RabbitMQ: vhost creation response: %#v", resp)
 	if err != nil {
@@ -78,7 +84,7 @@ func DeleteVhost(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("Error deleting RabbitMQ user: %s", resp.Status)
+		return fmt.Errorf("Error deleting RabbitMQ vhost '%s': %s", d.Id(), resp.Status)
 	}
 
 	return nil

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
   This can also be sourced from the `RABBITMQ_USERNAME` Environment Variable.
 * `password` - (Optional) Password for the given user. This can also be sourced
   from the `RABBITMQ_PASSWORD` Environment Variable.
-* `insecure` - (Optional) Trust self-signed certificates. This can also be sourced
+* `insecure` - (Optional) Boolean. Trust self-signed certificates. This can also be sourced
   from the `RABBITMQ_INSECURE` Environment Variable.
 * `cacert_file` - (Optional) The path to a custom CA / intermediate certificate.
   This can also be sourced from the `RABBITMQ_CACERT` Environment Variable.


### PR DESCRIPTION
We noticed that in the actual version we can't ensure the unicity while creating. 
For example If you create 2 vhosts with the same name --> it works (but it's an update not a create)
So we added exceptions in order to prevent the user to create a resource twice.
 