### PR TITLE
Recreate when changing exchange settings

### DIFF
--- a/rabbitmq/resource_exchange.go
+++ b/rabbitmq/resource_exchange.go
@@ -42,23 +42,27 @@ func resourceExchange() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 
 						"durable": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,
+							ForceNew: true,
 						},
 
 						"auto_delete": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,
+							ForceNew: true,
 						},
 
 						"arguments": {
 							Type:     schema.TypeMap,
 							Optional: true,
+							ForceNew: true,
 						},
 					},
 				},

--- a/rabbitmq/resource_exchange_test.go
+++ b/rabbitmq/resource_exchange_test.go
@@ -24,6 +24,12 @@ func TestAccExchange(t *testing.T) {
 					"rabbitmq_exchange.test", &exchangeInfo,
 				),
 			},
+			{
+				Config: testAccExchangeConfig_update,
+				Check: testAccExchangeCheck(
+					"rabbitmq_exchange.test", &exchangeInfo,
+				),
+			},
 		},
 	})
 }
@@ -99,5 +105,30 @@ resource "rabbitmq_exchange" "test" {
         type = "fanout"
         durable = false
         auto_delete = true
+    }
+}`
+
+const testAccExchangeConfig_update = `
+resource "rabbitmq_vhost" "test" {
+    name = "test"
+}
+
+resource "rabbitmq_permissions" "guest" {
+    user = "guest"
+    vhost = "${rabbitmq_vhost.test.name}"
+    permissions {
+        configure = ".*"
+        write = ".*"
+        read = ".*"
+    }
+}
+
+resource "rabbitmq_exchange" "test" {
+    name = "test"
+    vhost = "${rabbitmq_permissions.guest.vhost}"
+    settings {
+        type = "direct"
+        durable = true
+        auto_delete = false
     }
 }`


### PR DESCRIPTION
The `type`, `durable`, `auto_delete`, and `arguments` fields (e.g. all fields under `settings`) are not updatable (I double-checked by trying requests on the RMQ management API version 3.11.20), so changing those fields should trigger a re-creation of the exchange.
This PR makes field changes re-create the exchange, instead of planning an update then throwing a `doesn't support update` error when applying.

Tested with Terraform 1.3.2 and 1.7.5, on RMQ version 3.11.20

Pretty much this commit https://github.com/cyrilgdn/terraform-provider-rabbitmq/commit/3df07d37114006345a798956fd0eb3c1d34f2da4 but for exchanges.