### PR TITLE
feat(data_source): added default_user data source to fetch data from configured provider

### DIFF
--- a/rabbitmq/data_source_default_user.go
+++ b/rabbitmq/data_source_default_user.go
@@ -1,0 +1,34 @@
+package rabbitmq
+
+import (
+	"context"
+
+	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourcesDefaultUser() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcesReadDefaultUser,
+		Schema: map[string]*schema.Schema{
+			"username": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourcesReadDefaultUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	rmqc := meta.(*rabbithole.Client)
+
+	username := rmqc.Username
+
+	d.Set("username", username)
+	d.SetId(username)
+	return diags
+}

--- a/rabbitmq/provider.go
+++ b/rabbitmq/provider.go
@@ -103,9 +103,10 @@ func Provider() *schema.Provider {
 			"rabbitmq_shovel":              resourceShovel(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"rabbitmq_exchange": dataSourcesExchange(),
-			"rabbitmq_user":     dataSourcesUser(),
-			"rabbitmq_vhost":    dataSourcesVhost(),
+			"rabbitmq_exchange":     dataSourcesExchange(),
+			"rabbitmq_user":         dataSourcesUser(),
+			"rabbitmq_vhost":        dataSourcesVhost(),
+			"rabbitmq_default_user": dataSourcesDefaultUser(),
 		},
 
 		ConfigureFunc: providerConfigure,


### PR DESCRIPTION
## Feature
New dataSource to fetch the configured provider Username.

### Why
Since it's not possible to do natively in Terraform something like `rabbitmq.username` it makes it harder to modularize default configurations or more cumbersome to require adding a variable to injected in the module just to use the default user.
Defining this data source makes it possible to move this logic to inside a child module.


### Notes
I did try to re-use the `dataSourcesReadUser` function but I was having this `panic: interface conversion: interface {} is nil, not string`. An `easy` workaround is to simply use the data source to fetch the info