### PR TITLE
feat(rabbitmq_shovel): allow shovel to/from clusters

### DIFF
--- a/rabbitmq/resource_shovel.go
+++ b/rabbitmq/resource_shovel.go
@@ -3,6 +3,7 @@ package rabbitmq
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	rabbithole "github.com/michaelklishin/rabbit-hole/v3"
 
@@ -273,9 +274,7 @@ func ReadShovel(d *schema.ResourceData, meta any) error {
 	info["destination_publish_properties"] = shovelInfo.Definition.DestinationPublishProperties
 	info["destination_queue_arguments"] = shovelInfo.Definition.DestinationQueueArgs
 	info["destination_queue"] = shovelInfo.Definition.DestinationQueue
-	if len(shovelInfo.Definition.DestinationURI) > 0 {
-		info["destination_uri"] = shovelInfo.Definition.DestinationURI[0]
-	}
+	info["destination_uri"] = strings.Join(shovelInfo.Definition.DestinationURI, " ")
 	info["prefetch_count"] = shovelInfo.Definition.PrefetchCount
 	info["reconnect_delay"] = shovelInfo.Definition.ReconnectDelay
 	info["source_address"] = shovelInfo.Definition.SourceAddress
@@ -285,9 +284,7 @@ func ReadShovel(d *schema.ResourceData, meta any) error {
 	info["source_prefetch_count"] = shovelInfo.Definition.SourcePrefetchCount
 	info["source_protocol"] = shovelInfo.Definition.SourceProtocol
 	info["source_queue"] = shovelInfo.Definition.SourceQueue
-	if len(shovelInfo.Definition.SourceURI) > 0 {
-		info["source_uri"] = shovelInfo.Definition.SourceURI[0]
-	}
+	info["source_uri"] = strings.Join(shovelInfo.Definition.SourceURI, " ")
 
 	d.Set("name", shovelInfo.Name)
 	d.Set("vhost", shovelInfo.Vhost)
@@ -408,7 +405,7 @@ func setShovelDefinition(shovelMap map[string]any) interface{} {
 	}
 
 	if v, ok := shovelMap["destination_uri"].(string); ok {
-		shovelDefinition.DestinationURI = []string{v}
+		shovelDefinition.DestinationURI = strings.Fields(v)
 	}
 
 	if v, ok := shovelMap["prefetch_count"].(int); ok {
@@ -446,7 +443,7 @@ func setShovelDefinition(shovelMap map[string]any) interface{} {
 	}
 
 	if v, ok := shovelMap["source_uri"].(string); ok {
-		shovelDefinition.SourceURI = []string{v}
+		shovelDefinition.SourceURI = strings.Fields(v)
 	}
 
 	return *shovelDefinition

--- a/rabbitmq/resource_shovel_test.go
+++ b/rabbitmq/resource_shovel_test.go
@@ -34,6 +34,24 @@ func TestAccShovel(t *testing.T) {
 	})
 }
 
+func TestAccShovelCluster(t *testing.T) {
+	var shovelInfo rabbithole.ShovelInfo
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccShovelCheckDestroy(&shovelInfo),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccShovelConfig_cluster,
+				Check: testAccShovelCheck(
+					"rabbitmq_shovel.shovelCluster", &shovelInfo,
+				),
+			},
+		},
+	})
+}
+
 func testAccShovelCheck(rn string, shovelInfo *rabbithole.ShovelInfo) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rn]
@@ -62,8 +80,8 @@ func testAccShovelCheck(rn string, shovelInfo *rabbithole.ShovelInfo) resource.T
 				shovelInfo = &info
 				actualSourceExchange := shovelInfo.Definition.SourceExchange
 				actualSourceExchangeKey := shovelInfo.Definition.SourceExchangeKey
-				actualSourceUri := shovelInfo.Definition.SourceURI[0]
-				actualDestinationUri := shovelInfo.Definition.DestinationURI[0]
+				actualSourceUri := strings.Join(shovelInfo.Definition.SourceURI, " ")
+				actualDestinationUri := strings.Join(shovelInfo.Definition.DestinationURI, " ")
 				if actualSourceExchange != expectedSourceExchange {
 					return fmt.Errorf("SourceExchange was not set to [%s], was [%s]", expectedSourceExchange, actualSourceExchange)
 				}
@@ -153,6 +171,51 @@ resource "rabbitmq_shovel" "shovelTest" {
 		destination_queue_arguments = {
 			x-queue-type = "classic"
 		}
+	}
+}`
+
+const testAccShovelConfig_cluster = `
+resource "rabbitmq_vhost" "test" {
+    name = "test"
+}
+
+resource "rabbitmq_permissions" "guest" {
+    user = "guest"
+    vhost = "${rabbitmq_vhost.test.name}"
+    permissions {
+        configure = ".*"
+        write = ".*"
+        read = ".*"
+    }
+}
+
+resource "rabbitmq_exchange" "test" {
+    name = "test_exchange"
+    vhost = "${rabbitmq_permissions.guest.vhost}"
+    settings {
+        type = "fanout"
+        durable = false
+        auto_delete = true
+    }
+}
+
+resource "rabbitmq_queue" "test" {
+	name = "test_queue"
+	vhost = "${rabbitmq_exchange.test.vhost}"
+	settings {
+		durable = false
+		auto_delete = true
+	}
+}
+
+resource "rabbitmq_shovel" "shovelCluster" {
+	name = "shovelCluster"
+	vhost = "${rabbitmq_queue.test.vhost}"
+	info {
+		source_uri      = "amqp:///test"
+		source_exchange = "${rabbitmq_exchange.test.name}"
+		destination_uri = "amqp:///test amqp:///test"
+		destination_queue = "${rabbitmq_queue.test.name}"
 	}
 }`
 


### PR DESCRIPTION
This allows using a cluster as endpoints for shovels. Example:

```
locals {
  rabbitmq_cluster_vms = join(" ", [
    "amqp://foo:bar@10.1.8.4/baz",
    "amqp://foo:bar@10.1.8.5/baz",
    "amqp://foo:bar@10.1.8.6/baz",
  ])
}

resource "rabbitmq_shovel" "my_shovel" {
  provider = rabbitmq.some_instance
  name     = "my-shovel"
  vhost    = "/"
  info {
    source_uri           = "amqp://"
    source_exchange      = "some.exchange"
    source_delete_after  = "never"
    destination_uri      = local.rabbitmq_cluster_vms
    destination_exchange = "some.exchange"
    ack_mode             = "on-confirm"
    reconnect_delay      = 5
  }
}
```

Without this, it yields a validation error, also when I tried to put all endpoints in a single string.

Using this productively with OpenTofu.