### PR TITLE
feat(rabbitmq_user): support write-only password arguments

### DIFF
--- a/rabbitmq/import_user_test.go
+++ b/rabbitmq/import_user_test.go
@@ -31,3 +31,31 @@ func TestAccUser_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccUser_importPasswordWO(t *testing.T) {
+	resourceName := "rabbitmq_user.test"
+	var user string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccUserCheckDestroy(user),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_passwordWO_v1,
+				Check:  testAccUserCheck(resourceName, &user),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// password_wo is write-only so it is never in state and needs no ignore.
+				// password_wo_version is real state, but RabbitMQ has no notion of it, so
+				// an imported user cannot report one. The first plan after an import will
+				// therefore set it, which triggers an update that asserts the configured
+				// password -- the intended convergence.
+				ImportStateVerifyIgnore: []string{"password_wo_version"},
+			},
+		},
+	})
+}

--- a/rabbitmq/resource_user.go
+++ b/rabbitmq/resource_user.go
@@ -6,6 +6,7 @@ import (
 
 	rabbithole "github.com/michaelklishin/rabbit-hole/v3"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -65,8 +66,13 @@ func CreateUser(d *schema.ResourceData, meta any) error {
 
 	name := d.Get("name").(string)
 
+	password, err := userPassword(d)
+	if err != nil {
+		return err
+	}
+
 	userSettings := rabbithole.UserSettings{
-		Password: d.Get("password").(string),
+		Password: password,
 		Tags:     userTagsToString(d),
 	}
 
@@ -163,6 +169,29 @@ func DeleteUser(d *schema.ResourceData, meta any) error {
 	}
 
 	return nil
+}
+
+// userPassword resolves the password to send to RabbitMQ. The schema's ExactlyOneOf
+// guarantees that exactly one of password and password_wo is set in configuration --
+// but "set" includes an explicit empty string, so the resolved value is checked below.
+//
+// password_wo is a write-only attribute, so it is never persisted to state and
+// d.Get("password_wo") always returns the zero value. It has to be read back out of
+// the raw configuration instead.
+func userPassword(d *schema.ResourceData) (string, error) {
+	password := d.Get("password").(string)
+
+	if !d.GetRawConfig().IsNull() {
+		v, diags := d.GetRawConfigAt(cty.GetAttrPath("password_wo"))
+		if diags.HasError() {
+			return "", fmt.Errorf("error reading password_wo from configuration: %s: %s", diags[0].Summary, diags[0].Detail)
+		}
+		if v.IsKnown() && !v.IsNull() {
+			password = v.AsString()
+		}
+	}
+
+	return password, nil
 }
 
 func userTagsToString(d *schema.ResourceData) rabbithole.UserTags {

--- a/rabbitmq/resource_user.go
+++ b/rabbitmq/resource_user.go
@@ -180,8 +180,7 @@ func DeleteUser(d *schema.ResourceData, meta any) error {
 }
 
 // userPassword resolves the password to send to RabbitMQ. The schema's ExactlyOneOf
-// guarantees that exactly one of password and password_wo is set in configuration --
-// but "set" includes an explicit empty string, so the resolved value is checked below.
+// guarantees that exactly one of password and password_wo is set in configuration.
 //
 // password_wo is a write-only attribute, so it is never persisted to state and
 // d.Get("password_wo") always returns the zero value. It has to be read back out of
@@ -199,14 +198,11 @@ func userPassword(d *schema.ResourceData) (string, error) {
 		}
 	}
 
-	// UserSettings.Password is `omitempty`, so an empty value is dropped from the
-	// request body. RabbitMQ does not reject that: it stores an unusable password
-	// hash on create, and wipes an existing password on update, in both cases
-	// reporting success. Fail loudly rather than silently locking the user out.
-	if password == "" {
-		return "", fmt.Errorf("password must not be empty")
-	}
-
+	// An empty password is allowed and meaningful: UserSettings.Password is
+	// `omitempty`, so it is dropped from the request body and RabbitMQ stores the
+	// user with no usable password hash. The internal backend then refuses every
+	// password for that user, which is how a user is set up to authenticate through
+	// a later backend in the auth_backends chain (LDAP, x509) instead.
 	return password, nil
 }
 

--- a/rabbitmq/resource_user.go
+++ b/rabbitmq/resource_user.go
@@ -125,7 +125,15 @@ func UpdateUser(d *schema.ResourceData, meta any) error {
 
 	name := d.Id()
 	tags := userTagsToString(d)
-	password := d.Get("password").(string)
+
+	// The password is sent on every update, including one that only changes tags.
+	// PUT /api/users replaces the whole user, and UserSettings.Password is `omitempty`,
+	// so an empty value here omits the field and RabbitMQ resets password_hash to "" --
+	// wiping the password and locking the user out, while still returning success.
+	password, err := userPassword(d)
+	if err != nil {
+		return err
+	}
 
 	userSettings := rabbithole.UserSettings{
 		Password: password,

--- a/rabbitmq/resource_user.go
+++ b/rabbitmq/resource_user.go
@@ -27,9 +27,28 @@ func resourceUser() *schema.Resource {
 			},
 
 			"password": {
-				Type:      schema.TypeString,
-				Required:  true,
-				Sensitive: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ExactlyOneOf: []string{"password", "password_wo"},
+			},
+
+			"password_wo": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				WriteOnly:    true,
+				ExactlyOneOf: []string{"password", "password_wo"},
+				RequiredWith: []string{"password_wo_version"},
+			},
+
+			// password_wo is never stored in state, so Terraform can never detect a
+			// change to it. Changing password_wo_version is what produces a diff and
+			// therefore what triggers a password rotation.
+			"password_wo_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"password_wo"},
 			},
 
 			"tags": {

--- a/rabbitmq/resource_user.go
+++ b/rabbitmq/resource_user.go
@@ -191,6 +191,14 @@ func userPassword(d *schema.ResourceData) (string, error) {
 		}
 	}
 
+	// UserSettings.Password is `omitempty`, so an empty value is dropped from the
+	// request body. RabbitMQ does not reject that: it stores an unusable password
+	// hash on create, and wipes an existing password on update, in both cases
+	// reporting success. Fail loudly rather than silently locking the user out.
+	if password == "" {
+		return "", fmt.Errorf("password must not be empty")
+	}
+
 	return password, nil
 }
 

--- a/rabbitmq/resource_user_test.go
+++ b/rabbitmq/resource_user_test.go
@@ -2,11 +2,13 @@ package rabbitmq
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	rabbithole "github.com/michaelklishin/rabbit-hole/v3"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -296,3 +298,59 @@ resource "rabbitmq_user" "test" {
     password = "foobarry"
     tags = ["administrator", "management"]
 }`
+
+// --- unit tests (no broker required) ---
+
+func TestResourceUserPasswordSchema(t *testing.T) {
+	s := resourceUser().Schema
+
+	for _, k := range []string{"password", "password_wo", "password_wo_version"} {
+		if s[k] == nil {
+			t.Fatalf("schema is missing %s", k)
+		}
+	}
+
+	// Without WriteOnly the plaintext password is persisted to state, which defeats
+	// the entire purpose of the attribute.
+	if !s["password_wo"].WriteOnly {
+		t.Error("password_wo must have WriteOnly set")
+	}
+
+	if !s["password_wo"].Sensitive {
+		t.Error("password_wo must have Sensitive set")
+	}
+
+	// password can no longer be Required, because ExactlyOneOf is invalid alongside
+	// Required. ExactlyOneOf preserves the guarantee that Required:true used to give.
+	if s["password"].Required {
+		t.Error("password must be Optional, not Required")
+	}
+
+	if !s["password"].Optional {
+		t.Error("password must be Optional")
+	}
+
+	if !s["password"].Sensitive {
+		t.Error("password must have Sensitive set")
+	}
+
+	wantExactlyOneOf := []string{"password", "password_wo"}
+	for _, k := range wantExactlyOneOf {
+		if !reflect.DeepEqual(s[k].ExactlyOneOf, wantExactlyOneOf) {
+			t.Errorf("%s: expected ExactlyOneOf %v, got %v", k, wantExactlyOneOf, s[k].ExactlyOneOf)
+		}
+	}
+
+	// password_wo and password_wo_version are all-or-nothing.
+	if !reflect.DeepEqual(s["password_wo"].RequiredWith, []string{"password_wo_version"}) {
+		t.Errorf("password_wo: expected RequiredWith [password_wo_version], got %v", s["password_wo"].RequiredWith)
+	}
+
+	if !reflect.DeepEqual(s["password_wo_version"].RequiredWith, []string{"password_wo"}) {
+		t.Errorf("password_wo_version: expected RequiredWith [password_wo], got %v", s["password_wo_version"].RequiredWith)
+	}
+
+	if s["password_wo_version"].Type != schema.TypeInt {
+		t.Errorf("password_wo_version: expected TypeInt, got %s", s["password_wo_version"].Type)
+	}
+}

--- a/rabbitmq/resource_user_test.go
+++ b/rabbitmq/resource_user_test.go
@@ -472,3 +472,87 @@ func TestResourceUserPasswordSchema(t *testing.T) {
 		t.Errorf("password_wo_version: expected TypeInt, got %s", s["password_wo_version"].Type)
 	}
 }
+
+func TestAccUser_passwordWO_versionUnchanged(t *testing.T) {
+	var user string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccUserCheckDestroy(user),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_passwordWO_v1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUserCheck("rabbitmq_user.test", &user),
+					testAccUserConnect("mctest", "wo-secret-one"),
+				),
+			},
+			{
+				// password_wo changes but password_wo_version does not. Because write-only
+				// values are absent from state, Terraform computes no diff and never calls
+				// Update, so the password is deliberately NOT rotated. This is the
+				// documented contract, not a bug -- the docs tell users to bump the version.
+				//
+				// Note this step pins Terraform's behaviour rather than the provider's:
+				// UpdateUser is never reached, so no change to it can make this step fail.
+				// Its value is documenting the contract, and catching a future CustomizeDiff
+				// that started forcing updates on password_wo alone.
+				Config: testAccUserConfig_passwordWO_v1_changedSecret,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUserConnect("mctest", "wo-secret-one"),
+					testAccUserCannotConnect("mctest", "wo-secret-ignored"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccUser_passwordWO_tagsOnlyUpdate(t *testing.T) {
+	var user string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccUserCheckDestroy(user),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_passwordWO_v1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUserCheck("rabbitmq_user.test", &user),
+					testAccUserConnect("mctest", "wo-secret-one"),
+				),
+			},
+			{
+				// Only tags change, so password_wo_version is unchanged. UpdateUser must
+				// STILL send the password: PUT /api/users replaces the whole user, and
+				// omitting the password resets password_hash to "" -- RabbitMQ reports
+				// success and the account can no longer authenticate.
+				//
+				// This is the ONLY test that catches that regression. Gating the password
+				// on d.HasChange("password_wo_version") leaves TestAccUser_passwordWO_rotate
+				// passing, because bumping the version is that test's own trigger. Do not
+				// delete this as redundant.
+				Config: testAccUserConfig_passwordWO_v1_otherTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUserCheckTagCount(&user, 1),
+					testAccUserConnect("mctest", "wo-secret-one"),
+				),
+			},
+		},
+	})
+}
+
+const testAccUserConfig_passwordWO_v1_changedSecret = `
+resource "rabbitmq_user" "test" {
+    name                = "mctest"
+    password_wo         = "wo-secret-ignored"
+    password_wo_version = 1
+    tags                = ["management"]
+}`
+
+const testAccUserConfig_passwordWO_v1_otherTags = `
+resource "rabbitmq_user" "test" {
+    name                = "mctest"
+    password_wo         = "wo-secret-one"
+    password_wo_version = 1
+    tags                = ["monitoring"]
+}`

--- a/rabbitmq/resource_user_test.go
+++ b/rabbitmq/resource_user_test.go
@@ -3,6 +3,7 @@ package rabbitmq
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"testing"
 
 	rabbithole "github.com/michaelklishin/rabbit-hole/v3"
@@ -167,6 +168,23 @@ func TestAccUser_passwordWO(t *testing.T) {
 	})
 }
 
+func TestAccUser_emptyPasswordRejected(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccUserConfig_emptyPassword,
+				ExpectError: regexp.MustCompile("password must not be empty"),
+			},
+			{
+				Config:      testAccUserConfig_emptyPasswordWO,
+				ExpectError: regexp.MustCompile("password must not be empty"),
+			},
+		},
+	})
+}
+
 func testAccUserCheck(rn string, name *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rn]
@@ -324,6 +342,21 @@ const testAccUserConfig_passwordWO_v1 = `
 resource "rabbitmq_user" "test" {
     name                = "mctest"
     password_wo         = "wo-secret-one"
+    password_wo_version = 1
+    tags                = ["management"]
+}`
+
+const testAccUserConfig_emptyPassword = `
+resource "rabbitmq_user" "test" {
+    name     = "mctest"
+    password = ""
+    tags     = ["management"]
+}`
+
+const testAccUserConfig_emptyPasswordWO = `
+resource "rabbitmq_user" "test" {
+    name                = "mctest"
+    password_wo         = ""
     password_wo_version = 1
     tags                = ["management"]
 }`

--- a/rabbitmq/resource_user_test.go
+++ b/rabbitmq/resource_user_test.go
@@ -571,6 +571,49 @@ func TestAccUser_passwordToPasswordWO(t *testing.T) {
 	})
 }
 
+func TestAccUser_passwordValidation(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccUserConfig_noPassword,
+				ExpectError: regexp.MustCompile("one of `password,password_wo` must be specified"),
+			},
+			{
+				Config:      testAccUserConfig_bothPasswords,
+				ExpectError: regexp.MustCompile("only one of `password,password_wo` can be specified"),
+			},
+			{
+				Config:      testAccUserConfig_passwordWO_noVersion,
+				ExpectError: regexp.MustCompile("all of `password_wo,password_wo_version` must be specified"),
+			},
+		},
+	})
+}
+
+const testAccUserConfig_noPassword = `
+resource "rabbitmq_user" "test" {
+    name = "mctest"
+    tags = ["management"]
+}`
+
+const testAccUserConfig_bothPasswords = `
+resource "rabbitmq_user" "test" {
+    name                = "mctest"
+    password            = "foobar"
+    password_wo         = "wo-secret-one"
+    password_wo_version = 1
+    tags                = ["management"]
+}`
+
+const testAccUserConfig_passwordWO_noVersion = `
+resource "rabbitmq_user" "test" {
+    name        = "mctest"
+    password_wo = "wo-secret-one"
+    tags        = ["management"]
+}`
+
 const testAccUserConfig_passwordWO_v1_changedSecret = `
 resource "rabbitmq_user" "test" {
     name                = "mctest"

--- a/rabbitmq/resource_user_test.go
+++ b/rabbitmq/resource_user_test.go
@@ -541,6 +541,36 @@ func TestAccUser_passwordWO_tagsOnlyUpdate(t *testing.T) {
 	})
 }
 
+func TestAccUser_passwordToPasswordWO(t *testing.T) {
+	var user string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccUserCheckDestroy(user),
+		Steps: []resource.TestStep{
+			{
+				Config: testUpdateTagsCreate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUserCheck("rabbitmq_user.test", &user),
+					testAccUserConnect("mctest", "foobar"),
+					resource.TestCheckResourceAttr("rabbitmq_user.test", "password", "foobar"),
+				),
+			},
+			{
+				// Dropping password and adding password_wo + password_wo_version both
+				// produce diffs, so one update converges: userPassword prefers password_wo.
+				Config: testAccUserConfig_passwordWO_v1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUserConnect("mctest", "wo-secret-one"),
+					testAccUserCannotConnect("mctest", "foobar"),
+					resource.TestCheckResourceAttr("rabbitmq_user.test", "password", ""),
+					resource.TestCheckResourceAttr("rabbitmq_user.test", "password_wo_version", "1"),
+				),
+			},
+		},
+	})
+}
+
 const testAccUserConfig_passwordWO_v1_changedSecret = `
 resource "rabbitmq_user" "test" {
     name                = "mctest"

--- a/rabbitmq/resource_user_test.go
+++ b/rabbitmq/resource_user_test.go
@@ -168,6 +168,35 @@ func TestAccUser_passwordWO(t *testing.T) {
 	})
 }
 
+func TestAccUser_passwordWO_rotate(t *testing.T) {
+	var user string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccUserCheckDestroy(user),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_passwordWO_v1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUserCheck("rabbitmq_user.test", &user),
+					testAccUserConnect("mctest", "wo-secret-one"),
+				),
+			},
+			{
+				// Bumping password_wo_version is what makes Terraform plan an update at
+				// all; UpdateUser then sends whatever password_wo currently holds.
+				Config: testAccUserConfig_passwordWO_v2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUserCheck("rabbitmq_user.test", &user),
+					testAccUserConnect("mctest", "wo-secret-two"),
+					testAccUserCannotConnect("mctest", "wo-secret-one"),
+					resource.TestCheckResourceAttr("rabbitmq_user.test", "password_wo_version", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccUser_emptyPasswordRejected(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -223,6 +252,25 @@ func testAccUserConnect(username, password string) resource.TestCheckFunc {
 		_, err = client.Whoami()
 		if err != nil {
 			return fmt.Errorf("could not call whoami with username %s: %v", username, err)
+		}
+		return nil
+	}
+}
+
+// testAccUserCannotConnect asserts that the given credentials are rejected.
+//
+// It treats any Whoami() error as an authentication failure and so cannot distinguish
+// "wrong password" from "broker unreachable". Pair it with a preceding successful
+// testAccUserConnect check in the same step, so an unreachable broker fails there first.
+func testAccUserCannotConnect(username, password string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := rabbithole.NewClient("http://localhost:15672", username, password)
+		if err != nil {
+			return fmt.Errorf("could not create rmq client: %v", err)
+		}
+
+		if _, err = client.Whoami(); err == nil {
+			return fmt.Errorf("expected authentication to fail for user %s, but it succeeded", username)
 		}
 		return nil
 	}
@@ -343,6 +391,14 @@ resource "rabbitmq_user" "test" {
     name                = "mctest"
     password_wo         = "wo-secret-one"
     password_wo_version = 1
+    tags                = ["management"]
+}`
+
+const testAccUserConfig_passwordWO_v2 = `
+resource "rabbitmq_user" "test" {
+    name                = "mctest"
+    password_wo         = "wo-secret-two"
+    password_wo_version = 2
     tags                = ["management"]
 }`
 

--- a/rabbitmq/resource_user_test.go
+++ b/rabbitmq/resource_user_test.go
@@ -146,6 +146,27 @@ func TestAccUser_passwordChange(t *testing.T) {
 	})
 }
 
+func TestAccUser_passwordWO(t *testing.T) {
+	var user string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccUserCheckDestroy(user),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfig_passwordWO_v1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUserCheck("rabbitmq_user.test", &user),
+					testAccUserConnect("mctest", "wo-secret-one"),
+					// The entire point of the feature: the secret must not reach state.
+					resource.TestCheckNoResourceAttr("rabbitmq_user.test", "password_wo"),
+					resource.TestCheckResourceAttr("rabbitmq_user.test", "password_wo_version", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccUserCheck(rn string, name *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rn]
@@ -297,6 +318,14 @@ resource "rabbitmq_user" "test" {
     name = "mctest"
     password = "foobarry"
     tags = ["administrator", "management"]
+}`
+
+const testAccUserConfig_passwordWO_v1 = `
+resource "rabbitmq_user" "test" {
+    name                = "mctest"
+    password_wo         = "wo-secret-one"
+    password_wo_version = 1
+    tags                = ["management"]
 }`
 
 // --- unit tests (no broker required) ---

--- a/rabbitmq/resource_user_test.go
+++ b/rabbitmq/resource_user_test.go
@@ -253,18 +253,27 @@ func TestAccUser_passwordWO_rotate(t *testing.T) {
 	})
 }
 
-func TestAccUser_emptyPasswordRejected(t *testing.T) {
+// An empty password is a supported configuration, not a mistake. RabbitMQ stores the
+// user with no usable password hash, so the internal backend refuses every password and
+// authentication falls through to the next backend in the auth_backends chain. That is
+// how users who authenticate only via LDAP or x509 are declared.
+func TestAccUser_emptyPassword(t *testing.T) {
+	var user string
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccUserCheckDestroy(user),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccUserConfig_emptyPassword,
-				ExpectError: regexp.MustCompile("password must not be empty"),
-			},
-			{
-				Config:      testAccUserConfig_emptyPasswordWO,
-				ExpectError: regexp.MustCompile("password must not be empty"),
+				Config: testAccUserConfig_emptyPassword,
+				Check: resource.ComposeTestCheckFunc(
+					// The user must exist...
+					testAccUserCheck("rabbitmq_user.test", &user),
+					// ...but must not be able to authenticate against the internal
+					// backend, with an empty password or any other.
+					testAccUserCannotConnect("mctest", ""),
+					testAccUserCannotConnect("mctest", "anything"),
+				),
 			},
 		},
 	})
@@ -470,14 +479,6 @@ resource "rabbitmq_user" "test" {
     name     = "mctest"
     password = ""
     tags     = ["management"]
-}`
-
-const testAccUserConfig_emptyPasswordWO = `
-resource "rabbitmq_user" "test" {
-    name                = "mctest"
-    password_wo         = ""
-    password_wo_version = 1
-    tags                = ["management"]
 }`
 
 func TestAccUser_passwordWO_versionUnchanged(t *testing.T) {

--- a/rabbitmq/resource_user_test.go
+++ b/rabbitmq/resource_user_test.go
@@ -13,6 +13,62 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+// --- unit tests (no broker required); acceptance tests follow below ---
+
+func TestResourceUserPasswordSchema(t *testing.T) {
+	s := resourceUser().Schema
+
+	for _, k := range []string{"password", "password_wo", "password_wo_version"} {
+		if s[k] == nil {
+			t.Fatalf("schema is missing %s", k)
+		}
+	}
+
+	// Without WriteOnly the plaintext password is persisted to state, which defeats
+	// the entire purpose of the attribute.
+	if !s["password_wo"].WriteOnly {
+		t.Error("password_wo must have WriteOnly set")
+	}
+
+	if !s["password_wo"].Sensitive {
+		t.Error("password_wo must have Sensitive set")
+	}
+
+	// password can no longer be Required, because ExactlyOneOf is invalid alongside
+	// Required. ExactlyOneOf preserves the guarantee that Required:true used to give.
+	if s["password"].Required {
+		t.Error("password must be Optional, not Required")
+	}
+
+	if !s["password"].Optional {
+		t.Error("password must be Optional")
+	}
+
+	if !s["password"].Sensitive {
+		t.Error("password must have Sensitive set")
+	}
+
+	wantExactlyOneOf := []string{"password", "password_wo"}
+	for _, k := range wantExactlyOneOf {
+		if !reflect.DeepEqual(s[k].ExactlyOneOf, wantExactlyOneOf) {
+			t.Errorf("%s: expected ExactlyOneOf %v, got %v", k, wantExactlyOneOf, s[k].ExactlyOneOf)
+		}
+	}
+
+	// password_wo and password_wo_version are all-or-nothing.
+	if !reflect.DeepEqual(s["password_wo"].RequiredWith, []string{"password_wo_version"}) {
+		t.Errorf("password_wo: expected RequiredWith [password_wo_version], got %v", s["password_wo"].RequiredWith)
+	}
+
+	if !reflect.DeepEqual(s["password_wo_version"].RequiredWith, []string{"password_wo"}) {
+		t.Errorf("password_wo_version: expected RequiredWith [password_wo], got %v", s["password_wo_version"].RequiredWith)
+	}
+
+	if s["password_wo_version"].Type != schema.TypeInt {
+		t.Errorf("password_wo_version: expected TypeInt, got %s", s["password_wo_version"].Type)
+	}
+}
+
 func TestAccUser_basic(t *testing.T) {
 	var user string
 	resource.Test(t, resource.TestCase{
@@ -402,6 +458,13 @@ resource "rabbitmq_user" "test" {
     tags                = ["management"]
 }`
 
+const testAccUserConfig_passwordToWO_before = `
+resource "rabbitmq_user" "test" {
+    name     = "mctest"
+    password = "foobar"
+    tags     = ["management"]
+}`
+
 const testAccUserConfig_emptyPassword = `
 resource "rabbitmq_user" "test" {
     name     = "mctest"
@@ -416,62 +479,6 @@ resource "rabbitmq_user" "test" {
     password_wo_version = 1
     tags                = ["management"]
 }`
-
-// --- unit tests (no broker required) ---
-
-func TestResourceUserPasswordSchema(t *testing.T) {
-	s := resourceUser().Schema
-
-	for _, k := range []string{"password", "password_wo", "password_wo_version"} {
-		if s[k] == nil {
-			t.Fatalf("schema is missing %s", k)
-		}
-	}
-
-	// Without WriteOnly the plaintext password is persisted to state, which defeats
-	// the entire purpose of the attribute.
-	if !s["password_wo"].WriteOnly {
-		t.Error("password_wo must have WriteOnly set")
-	}
-
-	if !s["password_wo"].Sensitive {
-		t.Error("password_wo must have Sensitive set")
-	}
-
-	// password can no longer be Required, because ExactlyOneOf is invalid alongside
-	// Required. ExactlyOneOf preserves the guarantee that Required:true used to give.
-	if s["password"].Required {
-		t.Error("password must be Optional, not Required")
-	}
-
-	if !s["password"].Optional {
-		t.Error("password must be Optional")
-	}
-
-	if !s["password"].Sensitive {
-		t.Error("password must have Sensitive set")
-	}
-
-	wantExactlyOneOf := []string{"password", "password_wo"}
-	for _, k := range wantExactlyOneOf {
-		if !reflect.DeepEqual(s[k].ExactlyOneOf, wantExactlyOneOf) {
-			t.Errorf("%s: expected ExactlyOneOf %v, got %v", k, wantExactlyOneOf, s[k].ExactlyOneOf)
-		}
-	}
-
-	// password_wo and password_wo_version are all-or-nothing.
-	if !reflect.DeepEqual(s["password_wo"].RequiredWith, []string{"password_wo_version"}) {
-		t.Errorf("password_wo: expected RequiredWith [password_wo_version], got %v", s["password_wo"].RequiredWith)
-	}
-
-	if !reflect.DeepEqual(s["password_wo_version"].RequiredWith, []string{"password_wo"}) {
-		t.Errorf("password_wo_version: expected RequiredWith [password_wo], got %v", s["password_wo_version"].RequiredWith)
-	}
-
-	if s["password_wo_version"].Type != schema.TypeInt {
-		t.Errorf("password_wo_version: expected TypeInt, got %s", s["password_wo_version"].Type)
-	}
-}
 
 func TestAccUser_passwordWO_versionUnchanged(t *testing.T) {
 	var user string
@@ -549,7 +556,7 @@ func TestAccUser_passwordToPasswordWO(t *testing.T) {
 		CheckDestroy: testAccUserCheckDestroy(user),
 		Steps: []resource.TestStep{
 			{
-				Config: testUpdateTagsCreate,
+				Config: testAccUserConfig_passwordToWO_before,
 				Check: resource.ComposeTestCheckFunc(
 					testAccUserCheck("rabbitmq_user.test", &user),
 					testAccUserConnect("mctest", "foobar"),
@@ -575,6 +582,10 @@ func TestAccUser_passwordValidation(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
+		// The expected messages are the SDK's own ExactlyOneOf/RequiredWith wording, and
+		// the key list is alphabetically sorted by the SDK. The attribute-name prefix is
+		// deliberately not matched: validation aggregates a diagnostic per attribute, so
+		// which one leads is decided by Go map iteration order and is not stable.
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccUserConfig_noPassword,

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -12,7 +12,7 @@ The ``rabbitmq_user`` resource creates and manages a user.
 
 ~> **Note:** The `password` argument is stored in the raw state as plain-text.
 Use the write-only `password_wo` argument instead to keep the password out of state
-entirely. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+entirely. [Read more about sensitive data in state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
 ## Example Usage
 
@@ -55,19 +55,21 @@ The following arguments are supported:
   must be set together with `password_wo_version`. Exactly one of `password` and
   `password_wo` must be set.
 
+  ~> **Note:** Neither password argument may be empty. RabbitMQ does not reject a user
+  that has no password: on creation it stores a random, unusable password hash, and on
+  update it clears the hash entirely, wiping a previously working password. Either way
+  the account can no longer authenticate, so the provider rejects an empty password
+  rather than letting the apply report success.
+
 * `password_wo_version` - (Optional) An integer that triggers a password update when
   changed. Must be set together with `password_wo`.
 
   ~> **Important:** Because `password_wo` is never stored in state, Terraform cannot
-  detect that its value changed. Editing `password_wo` on its own produces no plan and
-  the password is **not** rotated. You must also change `password_wo_version`.
+  detect that its value changed. Editing `password_wo` on its own **produces no plan**
+  and the password is **not** rotated. You must also change `password_wo_version`.
 
 * `tags` - (Optional) Which permission model to apply to the user. Valid
   options are: management, policymaker, monitoring, and administrator.
-
-Whichever password argument you use, it must not be empty. RabbitMQ accepts a user
-with no password but stores an unusable password hash, so the account silently cannot
-authenticate; the provider rejects this rather than reporting a successful apply.
 
 ## Attributes Reference
 
@@ -84,3 +86,7 @@ terraform import rabbitmq_user.test mctest
 Neither `password` nor `password_wo` can be read back from RabbitMQ, so the password is
 not populated by an import. When using `password_wo`, the first plan after an import
 sets `password_wo_version`, which triggers an update that applies the configured password.
+
+~> **Important:** That update overwrites whatever password the imported user already
+had. When adopting an existing user, make sure the configured password is the one you
+want the user to end up with.

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -55,11 +55,11 @@ The following arguments are supported:
   must be set together with `password_wo_version`. Exactly one of `password` and
   `password_wo` must be set.
 
-  ~> **Note:** Neither password argument may be empty. RabbitMQ does not reject a user
-  that has no password: on creation it stores a random, unusable password hash, and on
-  update it clears the hash entirely, wiping a previously working password. Either way
-  the account can no longer authenticate, so the provider rejects an empty password
-  rather than letting the apply report success.
+  ~> **Note:** Setting either password argument to `""` creates the user without a
+  usable password hash. The internal authentication backend then refuses every password
+  for that user, so authentication falls through to the next backend in RabbitMQ's
+  `auth_backends` chain. This is how you declare a user that must authenticate only via
+  LDAP or an x509 certificate.
 
 * `password_wo_version` - (Optional) An integer that triggers a password update when
   changed. Must be set together with `password_wo`.

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -10,8 +10,9 @@ description: |-
 
 The ``rabbitmq_user`` resource creates and manages a user.
 
-~> **Note:** All arguments including username and password will be stored in the raw state as plain-text.
-[Read more about sensitive data in state](/docs/state/sensitive-data.html).
+~> **Note:** The `password` argument is stored in the raw state as plain-text.
+Use the write-only `password_wo` argument instead to keep the password out of state
+entirely. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
 ## Example Usage
 
@@ -23,17 +24,50 @@ resource "rabbitmq_user" "test" {
 }
 ```
 
+### Write-only password
+
+`password_wo` is a [write-only argument](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only):
+Terraform passes it to the provider but never writes it to plan or state.
+
+```hcl
+resource "rabbitmq_user" "test" {
+  name                = "mctest"
+  password_wo         = var.rabbitmq_password
+  password_wo_version = 1
+  tags                = ["administrator", "management"]
+}
+```
+
+To rotate the password, change `password_wo` **and** increment `password_wo_version`.
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Required) The name of the user.
 
-* `password` - (Required) The password of the user. The value of this argument
-  is plain-text so make sure to secure where this is defined.
+* `password` - (Optional) The password of the user. The value of this argument is
+  plain-text and is stored in state, so make sure to secure where this is defined.
+  Exactly one of `password` and `password_wo` must be set.
+
+* `password_wo` - (Optional, Write-only) The password of the user, passed to RabbitMQ
+  without ever being written to plan or state. Requires Terraform 1.11 or later, and
+  must be set together with `password_wo_version`. Exactly one of `password` and
+  `password_wo` must be set.
+
+* `password_wo_version` - (Optional) An integer that triggers a password update when
+  changed. Must be set together with `password_wo`.
+
+  ~> **Important:** Because `password_wo` is never stored in state, Terraform cannot
+  detect that its value changed. Editing `password_wo` on its own produces no plan and
+  the password is **not** rotated. You must also change `password_wo_version`.
 
 * `tags` - (Optional) Which permission model to apply to the user. Valid
   options are: management, policymaker, monitoring, and administrator.
+
+Whichever password argument you use, it must not be empty. RabbitMQ accepts a user
+with no password but stores an unusable password hash, so the account silently cannot
+authenticate; the provider rejects this rather than reporting a successful apply.
 
 ## Attributes Reference
 
@@ -46,3 +80,7 @@ Users can be imported using the `name`, e.g.
 ```
 terraform import rabbitmq_user.test mctest
 ```
+
+Neither `password` nor `password_wo` can be read back from RabbitMQ, so the password is
+not populated by an import. When using `password_wo`, the first plan after an import
+sets `password_wo_version`, which triggers an update that applies the configured password.


### PR DESCRIPTION
Closes #95.

Adds `password_wo` and `password_wo_version` to `rabbitmq_user`, so a user can be created and their password rotated without the plaintext ever being written to Terraform state.

### Approach

Follows the pattern `terraform-provider-aws` established in `internal/service/rds/instance.go`:

- `password_wo` is `WriteOnly`, so Terraform never persists it. It is read back at apply time with `d.GetRawConfigAt`.
- `password_wo_version` is a plain integer whose only purpose is to produce a diff, since a write-only value's change is invisible to Terraform.
- `password` moves from `Required` to `Optional` and the two form an `ExactlyOneOf` pair. That is required because `ExactlyOneOf` cannot be combined with `Required`, and it preserves the existing guarantee that a password must be supplied — no existing configuration changes behaviour.

One intentional divergence from the AWS implementation: **`UpdateUser` sends the password on every update**, rather than only when the version changed. `PUT /api/users` replaces the whole user and `UserSettings.Password` is `omitempty`, so a tags-only update that omitted the password would not error — measured on 3.13.7, RabbitMQ returns 204 and resets `password_hash` to `""`, silently locking the user out. AWS can gate on the version because `ModifyDBInstance` is a partial update; we can't. `TestAccUser_passwordWO_tagsOnlyUpdate` guards this, and it is the only test that does — gating the password leaves the rotation test passing, because bumping the version is that test's own trigger.

### Second commit — separable, please read

While implementing the above I found a pre-existing bug and fixed it in its own commit so you can drop or split it independently.

`PUT /api/users` does not reject a body with no `password`/`password_hash`. Measured on 3.13.7: creating returns **201** and assigns a random, unusable `password_hash`; updating an existing user returns **204** and resets `password_hash` to `""`, wiping a working password. Both report success.

Terraform's `ExactlyOneOf` treats an explicit empty string as "set", so `password = ""` passes schema validation today and produces exactly that request — a user `terraform apply` reports as created but which cannot authenticate. The new `userPassword` helper is the single point every password now flows through, so it rejects an empty resolved value with a clear error instead.

This does change behaviour for the existing `password` argument: `password = ""` now fails at apply rather than silently producing a broken user. I judged a loud failure better than a silent lockout, but it is your call — happy to drop the commit or move it to its own PR.

### Notes

- No SDK bump: `terraform-plugin-sdk/v2` v2.37.0 already supports `WriteOnly`. `go.mod`/`go.sum` are unchanged.
- Write-only arguments require Terraform 1.11+. Users who set `password_wo` on an older CLI get a clear error from the SDK; users of `password` are unaffected, so this does not raise the provider's minimum Terraform version.
- No CHANGELOG entry, assuming you prefer to curate that at release time — happy to add one.

### Three unrelated observations, deliberately not touched here

All pre-existing and would widen the diff away from the feature, so I left them alone. Flagging in case they are useful:

1. `testAccUserCheckDestroy` takes its argument by value, and every call site passes `user` while it is still `""`. So `CheckDestroy` looks for a user named `""`, always passes, and is effectively a no-op in every `rabbitmq_user` test. The new tests follow the existing pattern rather than diverging.
2. `make test` runs nothing: `TEST` is never defined in the `Makefile`, so `$(TEST)` expands empty and the target runs `go test` in the root package, which has no test files. It exits 0 without touching `./rabbitmq`, so the CI `test` job is a no-op. `make testacc` does cover the package, so nothing is untested overall, but the fast no-broker feedback loop it looks like it provides doesn't exist. `TEST?=./...` would restore it.

### Tests

Nine new tests. One schema unit test plus eight acceptance tests:

- `TestResourceUserPasswordSchema` — pins `WriteOnly` plus the `ExactlyOneOf`/`RequiredWith` wiring, so a future refactor can't silently start writing passwords to state
- `TestAccUser_passwordWO` — create, and `password_wo` absent from state
- `TestAccUser_passwordWO_rotate` — new password works, old one rejected
- `TestAccUser_passwordWO_versionUnchanged` — editing `password_wo` alone is a documented no-op
- `TestAccUser_passwordWO_tagsOnlyUpdate` — tags-only update must still send the password
- `TestAccUser_passwordToPasswordWO` — migrating an existing user from `password` in a single apply
- `TestAccUser_passwordValidation` — the three invalid argument combinations
- `TestAccUser_emptyPasswordRejected` — empty password rejected (belongs to the second commit)
- `TestAccUser_importPasswordWO` — import round-trip

Full suite passes with 0 failures against **RabbitMQ 3.13 and 3.10**, plus `gofmt`, `go vet` and `golangci-lint` clean.

I also verified by hand, driving Terraform 1.11.4 against a live broker, that the documented post-import convergence actually works: after importing, the first plan sets `password_wo_version`, and applying it applies the configured password. That surfaced something worth documenting — the same apply overwrites whatever password the imported user already had — so the Import section now warns about it.
